### PR TITLE
Fixed error "build.fsx(91,1): error FS1161: TABs are not allowed in F# c...

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -88,7 +88,7 @@ Target "CreatePackages" (fun _ ->
             Summary = "Tools to help you build solutions on the Microsoft Azure platform."
             WorkingDir = workingDir
             Version = version }) "./nuget/RedDog.ServiceBus.nuspec"
-			
+
     // Prepare RedDog.Messenger.
     let workingDir = packagingDir @@ "RedDog.Messenger"
     let net40Dir = workingDir @@ "lib/net40-full/"


### PR DESCRIPTION
Fixed error "build.fsx(91,1): error FS1161: TABs are not allowed in F# code unless the #indent "off" option is used" when executing build.cmd.
